### PR TITLE
Added script to publish docs to gh-pages

### DIFF
--- a/publish_gh_pages.sh
+++ b/publish_gh_pages.sh
@@ -1,0 +1,12 @@
+# Create a temporary directory for publishing your element and cd into it
+mkdir temp && cd temp
+
+# Run the gp.sh script. This will allow you to push a demo-friendly
+# version of your page and its dependencies to a GitHub pages branch
+# of your repository (gh-pages). Below, we pass in a GitHub username
+# and the repo name for our element
+curl -s https://cdn.rawgit.com/Polymer/tools/b753dfb5/bin/gp.sh | bash -s EdgeVerve oe-data-table
+
+# Finally, clean-up your temporary directory as you no longer require it
+cd..
+rm -rf temp


### PR DESCRIPTION
In this PR, I have added a script which publishes the documentation & demo of the component to [GitHub Pages](http://pages.github.com/).

The script is a modified version of [publishing instruction](https://www.polymer-project.org/1.0/docs/tools/reusable-elements#publishing-a-demo-and-landing-page-for-your-element) provided by `Polymer`.

Publishing to `GitHub Pages` will let us host the component's document and demo using GitHub hosted servers. 

Hosting in `GitHub Pages` also let us build and publish only the component that is changed.

This script can be modified/consumed on the build server to auto-publish.

The preview of `GitHub` hosted content of `oe-data-table` can be accessed [here](http://sasivarnan.github.io/oe-data-table), which generated from my fork.